### PR TITLE
Add clarity to client tests

### DIFF
--- a/CarbonTests/Net/ClientTests.cs
+++ b/CarbonTests/Net/ClientTests.cs
@@ -6,10 +6,9 @@ namespace CarbonTests.Net
 	[TestClass]
     public class ClientTests
     {
-        //Use https://www.mocky to build request to test
-
         [TestMethod]
 		[TestCategory("Smoke")]
+		[TestCategory("Get")]
         public void GetSendsValidGetRequest()
         {
 			var res = new Client().Get("http://httpbin.org/get");
@@ -18,6 +17,7 @@ namespace CarbonTests.Net
 
         [TestMethod]
 		[TestCategory("Smoke")]
+		[TestCategory("Post")]
         public void PostSendsValidPostRequest()
         {
 			var res = new Client().Post("http://httpbin.org/post", new { message = "test" });
@@ -26,10 +26,29 @@ namespace CarbonTests.Net
 
 		[TestMethod]
 		[TestCategory("Smoke")]
+		[TestCategory("Put")]
         public void PutSendsValidPutRequest()
         {
 			var res = new Client().Put("http://httpbin.org/put", new { message = "test" });
 			Assert.IsNotNull(res);
+		}
+
+		[TestMethod]
+		[TestCategory("Post")]
+		public void PostSendsDataInRequest()
+		{
+			string postTestString = "ThisIsThePostTestStringImLookingFor";
+			var res = new Client().Post("http://httpbin.org/post", new { message = postTestString });
+			Assert.IsTrue(res.Contains(postTestString), "Expected string was not found in response");
+		}
+
+		[TestMethod]
+		[TestCategory("Put")]
+		public void PutSendsDataInRequest()
+		{
+			string putTestString = "ThisIsThePutTestStringImLookingFor";
+			var res = new Client().Put("http://httpbin.org/put", new { message = putTestString });
+			Assert.IsTrue(res.Contains(putTestString), "Expected string was not found in response");
 		}
 	}
 }

--- a/CarbonTests/Net/ClientTests.cs
+++ b/CarbonTests/Net/ClientTests.cs
@@ -1,63 +1,35 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Carbon.Net;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Carbon.Net.Tests
+namespace CarbonTests.Net
 {
-    [TestClass()]
+	[TestClass]
     public class ClientTests
     {
         //Use https://www.mocky to build request to test
 
-        [TestMethod()]
-        public void GetTest()
+        [TestMethod]
+		[TestCategory("Smoke")]
+        public void GetSendsValidGetRequest()
         {
-            try
-            {
-                var res = new Client().Get("http://www.mocky.io/v2/5ab444412f00006400ca3b31");
-                Assert.IsNotNull(res);
-            }
-            catch (Exception ex)
-            {
-
-                Assert.Fail(ex.Message);
-            }
+			var res = new Client().Get("http://httpbin.org/get");
+			Assert.IsNotNull(res);
         }
 
-        [TestMethod()]
-        public void PostTest()
+        [TestMethod]
+		[TestCategory("Smoke")]
+        public void PostSendsValidPostRequest()
         {
-            try
-            {
-                var res = new Client().Post("http://www.mocky.io/v2/5ab444412f00006400ca3b31", new { message = "test" });
-                Assert.IsNotNull(res);
-            }
-            catch (Exception ex)
-            {
+			var res = new Client().Post("http://httpbin.org/post", new { message = "test" });
+			Assert.IsNotNull(res);
+		}
 
-                Assert.Fail(ex.Message);
-            }
-        }
-
-        [TestMethod()]
-        public void PutTest()
+		[TestMethod]
+		[TestCategory("Smoke")]
+        public void PutSendsValidPutRequest()
         {
-            try
-            {
-                var res = new Client().Put("http://www.mocky.io/v2/5ab444412f00006400ca3b31", new { message = "test"});
-                Assert.IsNotNull(res);
-            }
-            catch (Exception ex)
-            {
-
-                Assert.Fail(ex.Message);
-            }
-        }
-
-        
-    }
+			var res = new Client().Put("http://httpbin.org/put", new { message = "test" });
+			Assert.IsNotNull(res);
+		}
+	}
 }

--- a/CarbonTests/Net/ClientTests.cs
+++ b/CarbonTests/Net/ClientTests.cs
@@ -3,52 +3,52 @@ using Carbon.Net;
 
 namespace CarbonTests.Net
 {
-	[TestClass]
+    [TestClass]
     public class ClientTests
     {
         [TestMethod]
-		[TestCategory("Smoke")]
-		[TestCategory("Get")]
+        [TestCategory("Smoke")]
+        [TestCategory("Get")]
         public void GetSendsValidGetRequest()
         {
-			var res = new Client().Get("http://httpbin.org/get");
-			Assert.IsNotNull(res);
+            var res = new Client().Get("http://httpbin.org/get");
+            Assert.IsNotNull(res);
         }
 
         [TestMethod]
-		[TestCategory("Smoke")]
-		[TestCategory("Post")]
+        [TestCategory("Smoke")]
+        [TestCategory("Post")]
         public void PostSendsValidPostRequest()
         {
-			var res = new Client().Post("http://httpbin.org/post", new { message = "test" });
-			Assert.IsNotNull(res);
-		}
+            var res = new Client().Post("http://httpbin.org/post", new { message = "test" });
+            Assert.IsNotNull(res);
+        }
 
-		[TestMethod]
-		[TestCategory("Smoke")]
-		[TestCategory("Put")]
+        [TestMethod]
+        [TestCategory("Smoke")]
+        [TestCategory("Put")]
         public void PutSendsValidPutRequest()
         {
-			var res = new Client().Put("http://httpbin.org/put", new { message = "test" });
-			Assert.IsNotNull(res);
-		}
+            var res = new Client().Put("http://httpbin.org/put", new { message = "test" });
+            Assert.IsNotNull(res);
+        }
 
-		[TestMethod]
-		[TestCategory("Post")]
-		public void PostSendsDataInRequest()
-		{
-			string postTestString = "ThisIsThePostTestStringImLookingFor";
-			var res = new Client().Post("http://httpbin.org/post", new { message = postTestString });
-			Assert.IsTrue(res.Contains(postTestString), "Expected string was not found in response");
-		}
+        [TestMethod]
+        [TestCategory("Post")]
+        public void PostSendsDataInRequest()
+        {
+            string postTestString = "ThisIsThePostTestStringImLookingFor";
+            var res = new Client().Post("http://httpbin.org/post", new { message = postTestString });
+            Assert.IsTrue(res.Contains(postTestString), "Expected string was not found in response");
+        }
 
-		[TestMethod]
-		[TestCategory("Put")]
-		public void PutSendsDataInRequest()
-		{
-			string putTestString = "ThisIsThePutTestStringImLookingFor";
-			var res = new Client().Put("http://httpbin.org/put", new { message = putTestString });
-			Assert.IsTrue(res.Contains(putTestString), "Expected string was not found in response");
-		}
-	}
+        [TestMethod]
+        [TestCategory("Put")]
+        public void PutSendsDataInRequest()
+        {
+            string putTestString = "ThisIsThePutTestStringImLookingFor";
+            var res = new Client().Put("http://httpbin.org/put", new { message = putTestString });
+            Assert.IsTrue(res.Contains(putTestString), "Expected string was not found in response");
+        }
+    }
 }


### PR DESCRIPTION
- Removed `try`/`catch` from `ClientTests` as any exception will fail the test anyway.

- Mocky is good for checking responses but doesn't validate the request. I switched these tests to use [httpbin](http://httpbin.org/) which can validate the request. (ex `http://httpbin.org/get` will only respond with `200 OK` to `GET` requests) It also repeats your request in the response so you can validate what was received by the server.

- Added two more tests that validate the data is being sent when using `Post` and `Put`.

- Also added some categories to the tests and gave them names that better describe their purpose.